### PR TITLE
#3 Add Sentry exception tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ Sync bot to push ACMI API Wikidata links to Wikidata.
 ## Check the code for errors
 
 * Run the code linting: `./lint.sh`
+
+## Exception tracking
+
+To keep track of exceptions when running the sync, add your Sentry DSN to `bot_login.json` under `sentry`.
+
+ACMI exceptions are sent to: https://acmi.sentry.io/projects/wikidata-bot

--- a/acmi_bot.py
+++ b/acmi_bot.py
@@ -7,6 +7,7 @@ import time
 import pandas
 import pydash
 import requests
+import sentry_sdk
 from wikibaseintegrator import WikibaseIntegrator, datatypes, wbi_login
 from wikibaseintegrator.wbi_config import config as wbi_config
 from wikibaseintegrator.wbi_enums import ActionIfExists
@@ -34,6 +35,12 @@ if not login_path.exists():
 
 with open(login_path, encoding='utf-8') as credentials:
     credentials = json.load(credentials)
+
+# setup error tracking
+sentry_sdk.init(
+    dsn=credentials.get('sentry', ''),
+    traces_sample_rate=1.0,
+)
 
 # traverse api json to grab all acmi-side links.
 acmi_path = pathlib.Path.cwd() / 'acmi-api' / 'app' / 'json' / 'works'

--- a/bot_login.tmpl.json
+++ b/bot_login.tmpl.json
@@ -1,1 +1,5 @@
-{ "user": "<YOUR_USERNAME>", "pass": "<YOUR_PASSWORD>" }
+{
+    "user": "<YOUR_USERNAME>",
+    "pass": "<YOUR_PASSWORD>",
+    "sentry": "https://<YOUR_ID>.ingest.sentry.io/<YOUR_ID>"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ wikibaseintegrator==0.12.3
 flake8
 pylint
 isort
+
+# For error tracking
+sentry-sdk


### PR DESCRIPTION
Resolves #3 

- [x] Add Sentry to track exceptions when syncing

## Testing

1. Add the ACMI Sentry DSN to `bot_login.json` under `sentry`
1. Add an exception after Sentry initialises: `Exception('Wikidata sync test exception.')`
1. Run the script `./run.sh`
1. See the exception: https://acmi.sentry.io/projects/wikidata-bot